### PR TITLE
Set up CI, ensure that crate is no_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+on:
+  push:
+  schedule:
+    - cron: '30 3 * * 2'
+
+name: CI
+
+jobs:
+
+  test_stable:
+    name: Test (stable)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv7m-none-eabi
+          override: true
+      - name: Ensure that library compiles on ARMv7
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target thumbv7m-none-eabi
+      - name: Ensure that examples compile on ARMv7
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --examples --target thumbv7m-none-eabi
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --tests --all-features
+
+  clippy:
+    name: Run clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            components: clippy
+            override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
+  rustfmt:
+    name: Run rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            components: rustfmt
+            override: true
+      - run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ embedded-hal = { version = "0.2.3" }
 heapless = "0.5.1"
 nb = { version = "0.1.2" }
 ufmt = "0.1.0"
-log = {version = "0.4", default-features = false}
 
 [dev-dependencies]
 cortex-m = "0.6.1"
@@ -29,5 +28,6 @@ cortex-m-rtfm = "0.5.1"
 void = { version = "1.0.2", default-features = false }
 
 [target.'x86_64-unknown-linux-gnu'.dev-dependencies]
+log = {version = "0.4", default-features = false}
 env_logger = "0.7.1"
 embedded-hal-mock = "0.7.1"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # `AT Parser`
 
+[![Build status][workflow-badge]][workflow]
+[![Crates.io Version][crates-io-badge]][crates-io]
+[![Crates.io Downloads][crates-io-download-badge]][crates-io-download]
+
 > A driver support crate for AT-command based serial modules, using the [embedded-hal] traits.
 
 
@@ -66,3 +70,11 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+<!-- Badges -->
+[workflow]: https://github.com/MathiasKoch/at-rs/actions?query=workflow%3ACI
+[workflow-badge]: https://img.shields.io/github/workflow/status/MathiasKoch/at-rs/CI/master
+[crates-io]: https://crates.io/crates/at-rs
+[crates-io-badge]: https://img.shields.io/crates/v/at-rs.svg?maxAge=3600
+[crates-io-download]: https://crates.io/crates/at-rs
+[crates-io-download-badge]: https://img.shields.io/crates/d/at-rs.svg?maxAge=3600

--- a/examples/common/command.rs
+++ b/examples/common/command.rs
@@ -2,7 +2,7 @@
 //! Following https://www.spezial.com/sites/default/files/odin-w2-atcommands_manual_ubx-14044127.pdf
 
 use core::fmt::Write;
-use heapless::{String, Vec, ArrayLength};
+use heapless::{ArrayLength, String, Vec};
 
 use at::{utils, ATCommandInterface, ATRequestType, MaxCommandLen, MaxResponseLines};
 

--- a/examples/cortex-m-rt.rs
+++ b/examples/cortex-m-rt.rs
@@ -44,7 +44,9 @@ type SerialUSART2 = Serial<
 
 static mut REQ_Q: Option<Queue<Command, consts::U5, u8>> = None;
 static mut RES_Q: Option<Queue<Result<Response, ATError>, consts::U5, u8>> = None;
-static mut AT_PARSER: Option<ATParser<SerialUSART2, Command, consts::U1024, consts::U5, consts::U5>> = None;
+static mut AT_PARSER: Option<
+    ATParser<SerialUSART2, Command, consts::U1024, consts::U5, consts::U5>,
+> = None;
 
 #[entry]
 fn main() -> ! {

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use heapless::{
 use embedded_hal::timer::CountDown;
 
 use crate::error::Error;
-use crate::traits::{ATCommandInterface, ATRequestType, ATInterface};
+use crate::traits::{ATCommandInterface, ATInterface, ATRequestType};
 use crate::Response;
 
 type ReqProducer<Req, N> = Producer<'static, Req, N, u8>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 #[macro_use]
 extern crate nb;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use crate::traits::{ATCommandInterface, ATRequestType};
 use crate::Response;
 use crate::{MaxCommandLen, MaxResponseLines};
 
-use log::{error, info, trace, warn};
+use log::{error, trace, warn};
 
 type CmdConsumer<Req, N> = Consumer<'static, Req, N, u8>;
 type RespProducer<Res, N> = Producer<'static, Result<Res, ATError>, N, u8>;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,6 +12,7 @@ use crate::traits::{ATCommandInterface, ATRequestType};
 use crate::Response;
 use crate::{MaxCommandLen, MaxResponseLines};
 
+#[cfg(test)]
 use log::{error, trace, warn};
 
 type CmdConsumer<Req, N> = Consumer<'static, Req, N, u8>;
@@ -91,13 +92,17 @@ where
             Ok(c) => {
                 // FIXME: handle buffer being full
                 if self.rx_buf.push(c).is_err() {
+                    #[cfg(test)]
                     error!("RXBuf is full!\r");
                 }
             }
             Err(e) => match e {
                 nb::Error::WouldBlock => (),
                 nb::Error::Other(e) => {
+                    #[cfg(test)]
                     error!("rx buffer error: {:?}\r", e);
+                    #[cfg(not(test))] // Silence unused variable warning
+                    let _ = e;
                 }
             },
         }
@@ -108,6 +113,7 @@ where
             self.res_p.enqueue(response).ok();
         } else {
             // TODO: Handle response queue not ready!
+            #[cfg(test)]
             warn!("Response queue is not ready!");
         }
     }
@@ -129,6 +135,7 @@ where
             .lines()
             .filter_map(|p| {
                 if !p.is_empty() {
+                    #[cfg(test)]
                     trace!("{:?}", p);
                     Some(String::from(p))
                 } else {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -263,10 +263,7 @@ fn test_at_command() {
 
     spin!(parser, expected_response.len());
 
-    assert_eq!(
-        res_c.dequeue().unwrap().ok(),
-        Some(TestResponseType::None)
-    );
+    assert_eq!(res_c.dequeue().unwrap().ok(), Some(TestResponseType::None));
     cleanup!(parser, res_c);
 }
 
@@ -292,10 +289,7 @@ fn test_parameterized_command() {
 
     spin!(parser, expected_response.len());
 
-    assert_eq!(
-        res_c.dequeue().unwrap().ok(),
-        Some(TestResponseType::None)
-    );
+    assert_eq!(res_c.dequeue().unwrap().ok(), Some(TestResponseType::None));
     cleanup!(parser, res_c);
 }
 
@@ -346,10 +340,7 @@ fn test_error() {
 
     spin!(parser, expected_response.len());
 
-    assert_eq!(
-        res_c.dequeue().unwrap(),
-        Err(ATError::InvalidResponse)
-    );
+    assert_eq!(res_c.dequeue().unwrap(), Err(ATError::InvalidResponse));
     cleanup!(parser, res_c);
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use crate::{MaxCommandLen, MaxResponseLines};
 use embedded_hal::timer::CountDown;
-use heapless::{String, Vec, ArrayLength};
+use heapless::{ArrayLength, String, Vec};
 
 /// Trait to be implemented by device driver crates.
 ///
@@ -95,7 +95,10 @@ pub trait ATCommandInterface {
     type Response;
 
     fn get_cmd<N: ArrayLength<u8>>(&self) -> String<N>;
-    fn parse_resp(&self, response_lines: &mut Vec<String<MaxCommandLen>, MaxResponseLines>) -> Self::Response;
+    fn parse_resp(
+        &self,
+        response_lines: &mut Vec<String<MaxCommandLen>, MaxResponseLines>,
+    ) -> Self::Response;
     fn parse_unsolicited(response_line: &str) -> Option<Self::Response>;
 }
 


### PR DESCRIPTION
This sets up a GitHub workflow that does the following:

- Build the library on ARMv7 with Rust stable
- Build the examples on ARMv7 with Rust stable
- Run tests with Rust stable
- Run clippy

If you like rustfmt, I could even add a rustfmt check step.

There are also some other commits in here to make the tests actually pass. For example, the parser used the `log` crate which requires `std`.